### PR TITLE
Generate HTML subunit report

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -300,8 +300,11 @@ function run_tests() {
 
     # TODO: Sometimes this fails with 'subunit.v2.ParseError: Bad checksum - calculated'.
     #       This needs to be investigated.
-    # generate_subunit_report $subunitFile $resultDir `
-    #                         "test_results"
+    try {
+        generate_subunit_report $subunitFile $resultDir "test_results"
+    } catch {
+        log_message "failed to generate HTML subunit report. skipping"
+    }
 }
 
 ensure_dir_exists $resultDir

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -46,8 +46,8 @@ function generate_subunit_report($subunitPath, $reportDir, $reportName) {
     $textResultFile = "$reportDir\$reportName.txt"
     $htmlResultFile = "$reportDir\$reportName.html"
 
-    cmd /c "type $subunitPath | subunit-trace > $textResultFile"
-    subunit2html $subunitPath $htmlResultFile
+    safe_exec "type $subunitPath | subunit-trace" | Out-File -Encoding ascii -FilePath $textResultFile
+    safe_exec "subunit2html $subunitPath $htmlResultFile"
 }
 
 function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {


### PR DESCRIPTION
Previously, we noticed `generate_subunit_report` to be flaky, and it was disabled.

This change re-adds the HTML subunit report, but considered non-fatal. Also, make sure proper error checking is done in the `generate_subunit_report` function.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>