### PR TITLE
test runner fixes

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -206,6 +206,7 @@ function run_tests() {
         "ceph_test_rados_list_parallel.exe"="";
         "ceph_test_rados_open_pools_parallel.exe"="";
         "ceph_test_rados_watch_notify.exe"="";
+        "ceph_test_rados_op_speed"="";
     }
     # Tests that aren't supposed to be run automatically.
     $manualTests=@{

--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -333,7 +333,14 @@ function run_tests() {
     try {
         generate_subunit_report $subunitFile $resultDir "test_results"
     } catch {
-        log_message "failed to generate HTML subunit report. skipping"
+        log_message "Failed to generate HTML subunit report: $_"
+        if (test-path $subunitFile) {
+            $subunitHash = (Get-FileHash $subunitFile -Algorithm SHA256).Hash
+            log_message "subunit file: $subunitFile"
+            log_message "subunit sha256 hash: $subunitHash"
+        } else {
+            log_message "missing subunit file: $subunitFile"
+        }
     }
 }
 

--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -216,6 +216,19 @@ function run_tests() {
         # This test passes but it leaks a "sleep" subprocess which
         # hangs powershell's job mechanism.
         "unittest_subprocess.exe"="SubProcessTimed.SubshellTimedout";
+        # TODO: the following tests seem to use the AioTestData semaphore incorrectly.
+        # The same AioTestData structure is reused for multiple async callbacks, which
+        # implies multiple completion notifications. However, the semaphore is initialized
+        # with 0, so "wait" will return before subsequent "notify" calls complete.
+        # For this reason, we can have situations in which "notify" callbacks occur after
+        # the test completes and the AioTestData structure and semaphore are cleaned up,
+        # which leads to a crash:
+        #   * https://pastebin.com/raw/gh7CytHA
+        #   * https://pastebin.com/raw/2Yu90uEG
+        "ceph_test_rados_striper_api_aio.exe"=@(
+            "*.Flush*",
+            "*.RoundTrip*",
+            "*.IsSafe*")
         "ceph_test_signal_handlers.exe"="*";
         # TODO - we may stick to the client tests, but this may also
         # involve RGW, which we haven't covered yet.

--- a/test_host/set_userspace_crashdump_location.ps1
+++ b/test_host/set_userspace_crashdump_location.ps1
@@ -1,0 +1,43 @@
+Param(
+    [string]$dumpDir,
+    [int]$dumpCount,
+    [int]$dumpType
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$scriptLocation = [System.IO.Path]::GetDirectoryName(
+    $myInvocation.MyCommand.Definition)
+
+import-module "$scriptLocation\..\utils\windows\all.psm1"
+
+
+$werRegPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting"
+$localDumpsRegPath = "$werRegPath\LocalDumps" 
+
+if (!(Test-path $localDumpsRegPath)) {
+    log_message "Creating $localDumpsRegPath"
+    New-Item -Path $localDumpsRegPath
+}
+
+if ($PSBoundParameters.ContainsKey('dumpDir')) {
+    log_message "setting $localDumpsRegPath\DumpFolder to $dumpDir"
+    Set-ItemProperty `
+        -Path $localDumpsRegPath -Name "DumpFolder" `
+        -Value $dumpDir -Type ExpandString
+}
+
+if ($PSBoundParameters.ContainsKey('dumpCount')) {
+    log_message "setting $localDumpsRegPath\DumpCount to $dumpCount"
+    Set-ItemProperty `
+        -Path $localDumpsRegPath -Name "DumpCount" `
+        -Value $dumpCount -Type DWord
+}
+
+if ($PSBoundParameters.ContainsKey('dumpType')) {
+    log_message "setting $localDumpsRegPath\DumpType to $dumpType"
+    Set-ItemProperty `
+        -Path $localDumpsRegPath -Name "DumpType" `
+        -Value $dumpType -Type DWord
+}

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -81,7 +81,7 @@ function run_test_subunit($binPath, $resultDir,
 
     $startTime = get_unix_time
     try {
-        run_gtest $binPath $resultDir $timeout $args
+        run_test $binPath $resultDir $timeout $args
     }
     catch {
         $errMsg = $_.Exception.Message


### PR DESCRIPTION
This change provides the following test runner fixes and improvements:

* some broken tests are skipped
* run_test_subunit no longer expects the gtest framework to be used
* script for configuring Windows crash dumps
* additional info when failing to parse subunit reports: error, subunit file location and checksum)