### PR TITLE
Catch subunit-trace errors

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -328,12 +328,10 @@ function run_tests() {
                        -workerCount 1 `
                        -nonGTestList $nonGTestList
 
-    # TODO: Sometimes this fails with 'subunit.v2.ParseError: Bad checksum - calculated'.
-    #       This needs to be investigated.
     try {
         generate_subunit_report $subunitFile $resultDir "test_results"
     } catch {
-        log_message "Failed to generate HTML subunit report: $_"
+        log_message "subunit report failure: $_"
         if (test-path $subunitFile) {
             $subunitHash = (Get-FileHash $subunitFile -Algorithm SHA256).Hash
             log_message "subunit file: $subunitFile"

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -46,8 +46,18 @@ function generate_subunit_report($subunitPath, $reportDir, $reportName) {
     $textResultFile = "$reportDir\$reportName.txt"
     $htmlResultFile = "$reportDir\$reportName.html"
 
-    safe_exec "type $subunitPath | subunit-trace" | Out-File -Encoding ascii -FilePath $textResultFile
     safe_exec "subunit2html $subunitPath $htmlResultFile"
+
+    try {
+        safe_exec "type $subunitPath | subunit-trace" | `
+            Out-File -Encoding ascii -FilePath $textResultFile
+    } catch {
+        # subunit-trace returns a non-zero exit code when the subunit file is
+        # invalid OR when there are failed tests. This function is only
+        # concerned in generating the test report and shouldn't fail if there
+        # are test failures.
+        log_message "subunit-trace reports failures: $_"
+    }
 }
 
 function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {


### PR DESCRIPTION
Catch subunit-trace errors

subunit-trace returns a non-zero exit code if there are test failures. For this reason, the subunit html report no longer gets generated.

This commit will catch subunit-trace errors. If the subunit.out file is corrupted, subunit2html should also return a non-zero exit code.