### PR TITLE
run libcephfs tests sequentially

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -300,6 +300,8 @@ function run_tests() {
     $isolatedTests=@{
         "unittest_bufferlist.exe"="*-BufferList.read_file";
         "unittest_admin_socket.exe"="*";
+        # Different tests try to access or remove the same paths
+        "ceph_test_libcephfs*"="*";
     }
 
     # TODO: fix merging hashtables, allow the same suite to have some excluded


### PR DESCRIPTION
run libcephfs tests sequentially

There are multiple libcephfs tests that try to access or remove the same paths. For this reason, we'll avoid running them in parallel.