### PR TITLE
Improve test argument handling

### DIFF
--- a/test_host/install_python_requirements.ps1
+++ b/test_host/install_python_requirements.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+python -m pip install `
+    os-testr six python-dateutil requests prettytable

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -71,7 +71,9 @@ function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {
     }
 
     $cmd = ("cmd /c '$binPath --gtest_output=xml:$xmlOutputPath $gtestFilterArg " +
-            "> $consoleOutputPath 2>&1'")
+            ">> $consoleOutputPath 2>&1'")
+
+    echo $cmd | Out-File -Encoding ascii -FilePath $consoleOutputPath
     iex_with_timeout $cmd $timeout
 }
 
@@ -80,7 +82,9 @@ function run_test($binPath, $resultDir, $timeout=-1, $testArgs) {
     $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
 
     $cmd = ("cmd /c '$binPath $testArgs " +
-            "> $consoleOutputPath 2>&1'")
+            ">> $consoleOutputPath 2>&1'")
+
+    echo $cmd | Out-File -Encoding ascii -FilePath $consoleOutputPath
     iex_with_timeout $cmd $timeout
 }
 

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -60,10 +60,11 @@ function generate_subunit_report($subunitPath, $reportDir, $reportName) {
     }
 }
 
-function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {
+function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter, $testSuffix) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
-    $xmlOutputPath = join-path $resultDir ($binName + "_results.xml")
-    $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
+    $testName = $binName + $testSuffix
+    $xmlOutputPath = join-path $resultDir ($testName + "_results.xml")
+    $consoleOutputPath = join-path $resultDir ($testName + "_results.log")
     $gtestFilterArg = ""
 
     if ($testFilter) {
@@ -77,9 +78,10 @@ function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {
     iex_with_timeout $cmd $timeout
 }
 
-function run_test($binPath, $resultDir, $timeout=-1, $testArgs) {
+function run_test($binPath, $resultDir, $timeout=-1, $testArgs, $testSuffix) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
-    $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
+    $testName = $binName + $testSuffix
+    $consoleOutputPath = join-path $resultDir ($testName + "_results.log")
 
     $cmd = ("cmd /c '$binPath $testArgs " +
             ">> $consoleOutputPath 2>&1'")
@@ -89,13 +91,15 @@ function run_test($binPath, $resultDir, $timeout=-1, $testArgs) {
 }
 
 function run_test_subunit($binPath, $resultDir,
-                          $subunitOutputPath, $timeout=-1, $testArgs) {
+                          $subunitOutputPath, $timeout=-1,
+                          $testArgs, $testSuffix) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
-    $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
+    $testName = $binName + $testSuffix
+    $consoleOutputPath = join-path $resultDir ($testName + "_results.log")
 
     $startTime = get_unix_time
     try {
-        run_test $binPath $resultDir $timeout $testArgs
+        run_test $binPath $resultDir $timeout $testArgs $testSuffix
     }
     catch {
         $errMsg = $_.Exception.Message
@@ -107,15 +111,15 @@ function run_test_subunit($binPath, $resultDir,
 
         if ($failed) {
             if (! $errMsg ) {
-                $errMsg = "Test failed: $binName."
+                $errMsg = "Test failed: $testName."
             }
-            add_subunit_failure $subunitOutputPath $binName `
+            add_subunit_failure $subunitOutputPath $testName `
                                 $startTime $stopTime `
                                 $errMsg $consoleOutputPath
         }
         else {
-            $testDetails = "Test passed: $binName"
-            add_subunit_success $subunitOutputPath $binName `
+            $testDetails = "Test passed: $testName"
+            add_subunit_success $subunitOutputPath $testName `
                                 $startTime $stopTime `
                                 $testDetails $consoleOutputPath
         }
@@ -128,14 +132,15 @@ function get_gtest_list($binPath) {
 }
 
 function run_gtest_subunit($binPath, $resultDir, $timeout=-1, $testFilter,
-                           $subunitOutputPath) {
+                           $subunitOutputPath, $testSuffix) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
-    $xmlOutputPath = join-path $resultDir ($binName + "_results.xml")
-    $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
+    $testName = $binName + $testSuffix
+    $xmlOutputPath = join-path $resultDir ($testName + "_results.xml")
+    $consoleOutputPath = join-path $resultDir ($testName + "_results.log")
 
     $startTime = get_unix_time
     try {
-        run_gtest $binPath $resultDir $timeout $testFilter
+        run_gtest $binPath $resultDir $timeout $testFilter $testSuffix
     }
     catch {
         $errMsg = $_.Exception.Message
@@ -144,13 +149,13 @@ function run_gtest_subunit($binPath, $resultDir, $timeout=-1, $testFilter,
     finally {
         $stopTime = get_unix_time
         if (test-path $xmlOutputPath) {
-            gtest2subunit $xmlOutputPath $subunitOutputPath $binName
+            gtest2subunit $xmlOutputPath $subunitOutputPath $testName
         }
         else {
             if (! $errMsg ) {
                 $errMsg = "Missing output xml."
             }
-            add_subunit_failure $subunitOutputPath $binName `
+            add_subunit_failure $subunitOutputPath $testName `
                                 $startTime $stopTime `
                                 $errMsg $consoleOutputPath
         }

--- a/utils/windows/tests.psm1
+++ b/utils/windows/tests.psm1
@@ -75,23 +75,23 @@ function run_gtest($binPath, $resultDir, $timeout=-1, $testFilter) {
     iex_with_timeout $cmd $timeout
 }
 
-function run_test($binPath, $resultDir, $timeout=-1, $args) {
+function run_test($binPath, $resultDir, $timeout=-1, $testArgs) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
     $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
 
-    $cmd = ("cmd /c '$binPath $args " +
+    $cmd = ("cmd /c '$binPath $testArgs " +
             "> $consoleOutputPath 2>&1'")
     iex_with_timeout $cmd $timeout
 }
 
 function run_test_subunit($binPath, $resultDir,
-                          $subunitOutputPath, $timeout=-1, $args) {
+                          $subunitOutputPath, $timeout=-1, $testArgs) {
     $binName = (split-path -leaf $binPath) -replace ".exe$",""
     $consoleOutputPath = join-path $resultDir ($binName + "_results.log")
 
     $startTime = get_unix_time
     try {
-        run_test $binPath $resultDir $timeout $args
+        run_test $binPath $resultDir $timeout $testArgs
     }
     catch {
         $errMsg = $_.Exception.Message


### PR DESCRIPTION
This PR specifies the ceph_test_librbd_fsx required arguments. We'll also allow running the same test multiple times with different arguments, having suffixes to differentiate the test cases. The full command invocation will be included in the test log.

While at it, we'll add a trivial script to install our python dependencies.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>