### PR TITLE
Skip flaky libcephfs delegation tests

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -332,8 +332,10 @@ function run_tests() {
     # The following tests have to be run separately.
     $isolatedTests=@{
         "unittest_admin_socket.exe"="*";
-        # Different tests try to access or remove the same paths
-        "ceph_test_libcephfs*"="*";
+        # Multiple libcephfs tests try to access or remove the same paths.
+        # Also, we're skipping flaky delegation tests:
+        # https://github.com/ceph/ceph/pull/52427#issuecomment-1640325664
+        "ceph_test_libcephfs*"="-LibCephFS.Deleg*";
     }
 
     # TODO: fix merging hashtables, allow the same suite to have some excluded


### PR DESCRIPTION
There are a few libcephfs tests that set up a delegation and then issue a r/w open, ensuring that the delegation gets recalled.

The issue is that the tests also assert that the open request hasn't completed yet, which is flaky and started failing a lot more often recently.

In order to unblock the Windows job, we'll skip the flaky tests for now.