### PR TITLE
Update fsx test parameters

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -234,8 +234,8 @@ function run_tests() {
         "ceph_test_rados_watch_notify.exe"="";
         "ceph_test_rados_op_speed"="";
         "ceph_test_librbd_fsx.exe"=@{
-            "$rbdPoolName test_librbd_fsx0 -N 500"="librbd";
-            "$rbdPoolName test_librbd_fsx1 -N 500 -M -L -r 4096 -w 4096 -O"="wnbd"
+            "$rbdPoolName test_librbd_fsx0 -N 3000 -d"="librbd";
+            "$rbdPoolName test_librbd_fsx1 -N 3000 -M -L -r 4096 -w 4096 -d"="wnbd"
         };
     }
     # Tests that aren't supposed to be run automatically.


### PR DESCRIPTION
We're increasing the number of IO operations from 500 to 3000, also dropping the "-O" parameter so that the test won't use a fixed IO size.