### PR TITLE
Run perf counter tests in isolated mode

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -332,6 +332,7 @@ function run_tests() {
     # The following tests have to be run separately.
     $isolatedTests=@{
         "unittest_admin_socket.exe"="*";
+        "unittest_perf_counters*"="*";
         # Multiple libcephfs tests try to access or remove the same paths.
         # Also, we're skipping flaky delegation tests:
         # https://github.com/ceph/ceph/pull/52427#issuecomment-1640325664


### PR DESCRIPTION
Newly introduced perf counter tests are failing with admin socket errors when ran in parallel with other tests. We had similar issues with the admin socket tests, which are now executed in isolated mode.

For this reason, we'll add the perf counter tests to the isolated test list.