### PR TITLE
Skip LibCephFS.HugeSnapDiff tests

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -337,7 +337,11 @@ function run_tests() {
         # Multiple libcephfs tests try to access or remove the same paths.
         # Also, we're skipping flaky delegation tests:
         # https://github.com/ceph/ceph/pull/52427#issuecomment-1640325664
-        "ceph_test_libcephfs*"="-LibCephFS.Deleg*";
+        #
+        # The snapdiff tests, especially LibCephFS.HugeSnapDiff* take an
+        # excessive amount of time on some Jenkins nodes, possibly due to
+        # reduced resources.
+        "ceph_test_libcephfs*"="-LibCephFS.Deleg*:LibCephFS.HugeSnapDiff*";
     }
 
     # TODO: fix merging hashtables, allow the same suite to have some excluded


### PR DESCRIPTION
The snapdiff tests, especially LibCephFS.HugeSnapDiff* take an excessive amount of time on some Jenkins nodes, possibly due to the nodes having very few resources.

To avoid timeouts, we'll skip the LibCephFS.HugeSnapDiff* tests for now.

Successful job: https://paste.openstack.org/raw/baqWKQDSt39KHnr90V7u/
Failed job: https://paste.openstack.org/raw/bCbNHfyqeZrkMryLB3WE/