### PR TITLE
Skip LibRadosMiscConnectFailure.ConnectTimeout

### DIFF
--- a/test_host/run_tests.ps1
+++ b/test_host/run_tests.ps1
@@ -293,6 +293,9 @@ function run_tests() {
         # TODO: ensure that this won't affect the rados/rbd (e.g. we may
         # end up converting values other than error codes, which is wrong).
         "ceph_test_rados_api_tier_pp.exe"="*";
+        # The expected connection timeout is sometimes exceeded, possibly
+        # due to reduced timer or clock precision.
+        "ceph_test_rados_api_misc.exe"="LibRadosMiscConnectFailure.ConnectTimeout";
         # TODO: look into this. seems like a local error (ECANCELED) gets
         # converted to the unix value, yet the test expects the host error.
         "ceph_test_rados_api_aio_pp.exe"="LibRadosAio.OmapPP";


### PR DESCRIPTION
This test sets a connection timeout of 2s and asserts that the connection attempt completes in less than 4s.

On Windows, it sometimes takes between 5 and 6 seconds, leading to a test failure. This could be caused by reduced clock or timer precision.

```
    [ RUN      ] LibRadosMiscConnectFailure.ConnectTimeout
    /home/ubuntu/ceph/src/test/librados/misc.cc:87: Failure
    Expected: (dur) < (utime_t(4, 0)), actual: 5.987712 vs 4.000000
```

We're going to skip this test for the time being.